### PR TITLE
Consolidate HTTP/error helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "chrono",
  "directories",
  "env_logger",
- "flate2",
  "gpui",
  "gpui-component",
  "gpui-component-assets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ uuid = { version = "1.22.0", default-features = false, features = ["v4"] }
 semver = { version = "1.0", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 directories = "6.0"
-flate2 = "1.1.9"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.56"

--- a/flake.nix
+++ b/flake.nix
@@ -55,13 +55,13 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
             outputHashes = {
-              "collections-0.1.0" = "sha256-+9t67JeCwlI01nuWp1jONiyl/4u1O7ruzPYEj1+Jp2Q=";
-              "gpui-component-0.5.2" = "sha256-gCXOFwEpiaZrJfNhO3yO37qr6qX5rs+9/8ff2TqZXAQ=";
-              "naga-29.0.3" = "sha256-jwPdrd2XLvK5ddEutR/39OLMh2JU3UXNWIcJKCndh+U=";
+              "collections-0.1.0" = "sha256-BuY0YCmTlkGqrDLjOTatzWa/VoOo4kQtPxL7QkwjWTA=";
+              "gpui-component-0.5.2" = "sha256-BOUSwFpSECRvsNi+F5psCO4mvgyF7SAbJ01r6RyH3A8=";
               "zed-font-kit-0.14.1-zed" = "sha256-KXygi0olNQi5yM8eaJVykNDtbPMDjT+cWPBF8UrtXR4=";
               "zed-reqwest-0.12.15-zed" = "sha256-p4SiUrOrbTlk/3bBrzN/mq/t+1Gzy2ot4nso6w6S+F8=";
               "zed-scap-0.0.8-zed" = "sha256-BihiQHlal/eRsktyf0GI3aSWsUCW7WcICMsC2Xvb7kw=";
               "zed-xim-0.4.0-zed" = "sha256-pRT4Sz1JU9ros47/7pmIW9kosWOGMOItcnNd+VrvnpE=";
+              "wasm_thread-0.3.3" = "sha256-+lRLCIk0S6Y5ORYjDKsYYHia2FtoSoh+rWkQh7mnPBE=";
             };
           };
 

--- a/src/backend/api.rs
+++ b/src/backend/api.rs
@@ -227,10 +227,10 @@ pub fn fetch_servers() -> AppResult<Vec<Server>> {
 /// a non-implementing or unresponsive server from stalling a refresh — callers
 /// treat any error as "this server has no lobby list" and skip it.
 pub fn fetch_lobbies(host: &str, port: u16) -> AppResult<GamesResult> {
-    let client = reqwest::blocking::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(5))
-        .timeout(std::time::Duration::from_secs(8))
-        .build()?;
+    let client = crate::backend::services::http_download::http_client(
+        std::time::Duration::from_secs(5),
+        std::time::Duration::from_secs(8),
+    )?;
 
     let mut last_err = None;
     for scheme in ["https", "http"] {

--- a/src/backend/directories.rs
+++ b/src/backend/directories.rs
@@ -6,8 +6,8 @@ pub fn app_data_dir() -> AppResult<PathBuf> {
     if let Some(proj_dirs) = ProjectDirs::from("dev", "allofus", "Starlight") {
         Ok(proj_dirs.data_dir().to_path_buf())
     } else {
-        Err(AppError::State(
-            "Could not determine app data directory".to_string(),
+        Err(AppError::state(
+            "Could not determine app data directory",
         ))
     }
 }

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -2,58 +2,40 @@ use std::fmt::{Display, Formatter};
 
 pub type AppResult<T> = Result<T, AppError>;
 
+/// A backend failure carrying a user-presentable message. No structured
+/// variants — nothing in the app matches on error kind, they only display it.
 #[derive(Debug)]
-pub enum AppError {
-    Io(std::io::Error),
-    Http(String),
-    Zip(zip::result::ZipError),
-    Parse(String),
-    Process(String),
-    Platform(String),
-    Validation(String),
-    State(String),
-    Other(String),
-}
+pub struct AppError(pub String);
 
 impl AppError {
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+
     pub fn parse(message: impl Into<String>) -> Self {
-        Self::Parse(message.into())
+        Self(message.into())
     }
 
     pub fn process(message: impl Into<String>) -> Self {
-        Self::Process(message.into())
+        Self(message.into())
     }
 
     pub fn platform(message: impl Into<String>) -> Self {
-        Self::Platform(message.into())
-    }
-
-    pub fn validation(message: impl Into<String>) -> Self {
-        Self::Validation(message.into())
+        Self(message.into())
     }
 
     pub fn state(message: impl Into<String>) -> Self {
-        Self::State(message.into())
+        Self(message.into())
     }
 
     pub fn other(message: impl Into<String>) -> Self {
-        Self::Other(message.into())
+        Self(message.into())
     }
 }
 
 impl Display for AppError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "I/O error: {e}"),
-            Self::Http(e) => write!(f, "HTTP error: {e}"),
-            Self::Zip(e) => write!(f, "Zip error: {e}"),
-            Self::Parse(e) => write!(f, "Parse error: {e}"),
-            Self::Process(e) => write!(f, "Process error: {e}"),
-            Self::Platform(e) => write!(f, "Platform error: {e}"),
-            Self::Validation(e) => write!(f, "Validation error: {e}"),
-            Self::State(e) => write!(f, "State error: {e}"),
-            Self::Other(e) => write!(f, "Error: {e}"),
-        }
+        f.write_str(&self.0)
     }
 }
 
@@ -61,25 +43,25 @@ impl std::error::Error for AppError {}
 
 impl From<std::io::Error> for AppError {
     fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
+        Self(format!("I/O error: {value}"))
     }
 }
 
 impl From<reqwest::Error> for AppError {
     fn from(value: reqwest::Error) -> Self {
-        Self::Http(value.to_string())
+        Self(format!("HTTP error: {value}"))
     }
 }
 
 impl From<zip::result::ZipError> for AppError {
     fn from(value: zip::result::ZipError) -> Self {
-        Self::Zip(value)
+        Self(format!("Zip error: {value}"))
     }
 }
 
 impl From<serde_json::Error> for AppError {
     fn from(value: serde_json::Error) -> Self {
-        Self::Parse(value.to_string())
+        Self(format!("Parse error: {value}"))
     }
 }
 
@@ -90,6 +72,6 @@ mod tests {
     #[test]
     fn display_smoke() {
         let err = AppError::validation("invalid");
-        assert!(err.to_string().contains("Validation error"));
+        assert_eq!(err.to_string(), "invalid");
     }
 }

--- a/src/backend/services/bepinex_service.rs
+++ b/src/backend/services/bepinex_service.rs
@@ -107,7 +107,7 @@ pub fn install_bepinex(
 
     let temp = dest.with_extension("zip.tmp");
     emit("downloading", 0.0, "Downloading...", target_type, target_id);
-    download_file(&url, &temp, |dl, total| {
+    download_file(&url, &temp, None, None, |dl, total| {
         emit_download_progress(dl, total, target_type, target_id)
     })?;
 
@@ -147,7 +147,7 @@ pub fn download_bepinex_to_cache(
         BepInExTargetType::Cache,
         &architecture,
     );
-    download_file(&url, cache_file, |dl, total| {
+    download_file(&url, cache_file, None, None, |dl, total| {
         emit_download_progress(dl, total, BepInExTargetType::Cache, &architecture)
     })?;
 

--- a/src/backend/services/http_download.rs
+++ b/src/backend/services/http_download.rs
@@ -1,5 +1,6 @@
 use crate::backend::error::AppResult;
 use log::debug;
+use sha2::{Digest, Sha256};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -10,7 +11,28 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 const READ_CHUNK: usize = 64 * 1024;
 
-pub fn download_file<F>(url: &str, dest_path: &Path, mut on_progress: F) -> AppResult<()>
+/// Blocking HTTP client with the given timeouts, shared by every backend
+/// fetcher so connection behavior stays consistent.
+pub fn http_client(
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> AppResult<reqwest::blocking::Client> {
+    Ok(reqwest::blocking::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()?)
+}
+
+/// Stream `url` into `dest_path`, creating parent dirs, reporting
+/// `(downloaded, total)` per chunk. Optionally sends one extra header and
+/// hashes the body into `hasher` as it goes.
+pub fn download_file<F>(
+    url: &str,
+    dest_path: &Path,
+    extra_header: Option<(&str, String)>,
+    mut hasher: Option<&mut Sha256>,
+    mut on_progress: F,
+) -> AppResult<()>
 where
     F: FnMut(u64, Option<u64>),
 {
@@ -18,12 +40,13 @@ where
         fs::create_dir_all(parent)?;
     }
 
-    let client = reqwest::blocking::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(REQUEST_TIMEOUT)
-        .build()?;
+    let client = http_client(CONNECT_TIMEOUT, REQUEST_TIMEOUT)?;
 
-    let mut response = client.get(url).send()?.error_for_status()?;
+    let mut request = client.get(url);
+    if let Some((name, value)) = extra_header {
+        request = request.header(name, value);
+    }
+    let mut response = request.send()?.error_for_status()?;
     let total: Option<u64> = response.content_length();
 
     let mut file = File::create(dest_path)?;
@@ -35,12 +58,21 @@ where
         if n == 0 {
             break;
         }
+        if let Some(hasher) = hasher.as_deref_mut() {
+            hasher.update(&buf[..n]);
+        }
         file.write_all(&buf[..n])?;
         downloaded += n as u64;
         on_progress(downloaded, total);
     }
 
     Ok(())
+}
+
+/// Hex digest of everything hashed so far. Call after `download_file` when
+/// verifying a checksum.
+pub fn finish_digest(hasher: &mut Sha256) -> String {
+    crate::backend::services::hex_digest(std::mem::take(hasher).finalize())
 }
 
 pub fn extract_zip<F>(zip_path: &Path, dest_path: &Path, mut on_progress: F) -> AppResult<()>

--- a/src/backend/services/launch_service.rs
+++ b/src/backend/services/launch_service.rs
@@ -97,8 +97,8 @@ pub struct LaunchVanillaArgs {
 
 #[cfg(not(any(windows, target_os = "linux")))]
 fn build_game_command(_game_exe: &str) -> AppResult<Command> {
-    Err(AppError::Platform(
-        "Launching the game is not supported on this platform".to_string(),
+    Err(AppError::platform(
+        "Launching the game is not supported on this platform",
     ))
 }
 

--- a/src/backend/services/mod_download_service.rs
+++ b/src/backend/services/mod_download_service.rs
@@ -9,21 +9,14 @@ use uuid::Uuid;
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct ModDownloadProgress {
     pub mod_id: String,
-    pub downloaded: u64,
-    pub total: Option<u64>,
     pub progress: f64,
     pub stage: String,
 }
 
-fn emit_progress(mod_id: &str, downloaded: u64, total: Option<u64>, stage: &str) {
-    let progress = total
-        .map(|t| downloaded as f64 / t as f64 * 100.0)
-        .unwrap_or(0.0);
+fn emit_progress(mod_id: &str, progress: f64, stage: &str) {
     crate::backend::events::publish(crate::backend::events::BackendEvent::ModDownloadProgress(
         ModDownloadProgress {
             mod_id: mod_id.to_string(),
-            downloaded,
-            total,
             progress,
             stage: stage.to_string(),
         },
@@ -43,7 +36,7 @@ pub fn download_mod(
 
     let tracking_id = get_tracking_id()?;
 
-    emit_progress(&mod_id, 0, None, "connecting");
+    emit_progress(&mod_id, 0.0, "connecting");
 
     // Download to a `.part` file so a failed/interrupted download never
     // leaves a truncated plugin in place of the real one.
@@ -60,11 +53,12 @@ pub fn download_mod(
             // size is unknown/zero) so a large download doesn't flood the
             // event bus.
             let pct = total
-                .and_then(|t| (downloaded * 100).checked_div(t))
-                .unwrap_or(0) as i64;
-            if pct != last_pct {
-                last_pct = pct;
-                emit_progress(&mod_id, downloaded, total, "downloading");
+                .filter(|t| *t > 0)
+                .map(|t| downloaded as f64 / t as f64 * 100.0)
+                .unwrap_or(0.0);
+            if pct as i64 != last_pct {
+                last_pct = pct as i64;
+                emit_progress(&mod_id, pct, "downloading");
             }
         },
     );
@@ -74,7 +68,7 @@ pub fn download_mod(
         return Err(e);
     }
 
-    emit_progress(&mod_id, 0, None, "verifying");
+    emit_progress(&mod_id, 100.0, "verifying");
     let computed_checksum = finish_digest(&mut hasher);
     if let Some(expected) = expected_checksum.filter(|checksum| !checksum.is_empty())
         && computed_checksum != expected.to_lowercase()
@@ -85,10 +79,10 @@ pub fn download_mod(
         )));
     }
 
-    emit_progress(&mod_id, 0, None, "writing");
+    emit_progress(&mod_id, 100.0, "writing");
     fs::rename(&part_path, dest_path)?;
 
-    emit_progress(&mod_id, 0, None, "complete");
+    emit_progress(&mod_id, 100.0, "complete");
     info!("Mod download completed: {} -> {:?}", mod_id, dest_path);
     Ok(())
 }

--- a/src/backend/services/mod_download_service.rs
+++ b/src/backend/services/mod_download_service.rs
@@ -1,14 +1,10 @@
 use crate::backend::error::{AppError, AppResult};
-use log::{debug, info};
+use crate::backend::services::http_download::{download_file, finish_digest};
+use log::info;
 use sha2::{Digest, Sha256};
-use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::fs;
 use std::path::Path;
-use std::time::Duration;
 use uuid::Uuid;
-
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct ModDownloadProgress {
@@ -47,99 +43,57 @@ pub fn download_mod(
 
     let tracking_id = get_tracking_id()?;
 
-    let client = reqwest::blocking::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(REQUEST_TIMEOUT)
-        .build()?;
-
     emit_progress(&mod_id, 0, None, "connecting");
 
-    let mut response = client
-        .get(&url)
-        .header("X-Starlight-ID", &tracking_id)
-        .send()?
-        .error_for_status()?;
-
-    let total_size: Option<u64> = response.content_length();
-    debug!("Download size: {:?}", total_size);
-
+    // Download to a `.part` file so a failed/interrupted download never
+    // leaves a truncated plugin in place of the real one.
     let part_path = dest_path.with_extension("part");
-    let downloaded = match stream_and_verify(
-        &mod_id,
-        &mut response,
+    let mut hasher = Sha256::new();
+    let mut last_pct: i64 = -1;
+    let result = download_file(
+        &url,
         &part_path,
-        total_size,
-        expected_checksum,
-    ) {
-        Ok(downloaded) => downloaded,
-        Err(e) => {
-            let _ = fs::remove_file(&part_path);
-            return Err(e);
-        }
-    };
+        Some(("X-Starlight-ID", tracking_id)),
+        Some(&mut hasher),
+        |downloaded, total| {
+            // Throttle to whole-percent changes (or a single emit when the
+            // size is unknown/zero) so a large download doesn't flood the
+            // event bus.
+            let pct = total
+                .and_then(|t| (downloaded * 100).checked_div(t))
+                .unwrap_or(0) as i64;
+            if pct != last_pct {
+                last_pct = pct;
+                emit_progress(&mod_id, downloaded, total, "downloading");
+            }
+        },
+    );
 
-    emit_progress(&mod_id, downloaded, total_size, "writing");
+    if let Err(e) = result {
+        let _ = fs::remove_file(&part_path);
+        return Err(e);
+    }
+
+    emit_progress(&mod_id, 0, None, "verifying");
+    let computed_checksum = finish_digest(&mut hasher);
+    if let Some(expected) = expected_checksum.filter(|checksum| !checksum.is_empty())
+        && computed_checksum != expected.to_lowercase()
+    {
+        let _ = fs::remove_file(&part_path);
+        return Err(AppError::validation(format!(
+            "Checksum mismatch: expected {expected}, got {computed_checksum}"
+        )));
+    }
+
+    emit_progress(&mod_id, 0, None, "writing");
     fs::rename(&part_path, dest_path)?;
 
-    emit_progress(&mod_id, downloaded, total_size, "complete");
+    emit_progress(&mod_id, 0, None, "complete");
     info!("Mod download completed: {} -> {:?}", mod_id, dest_path);
     Ok(())
 }
 
-/// Streams the response body into `part_path`, hashing as it goes, and
-/// verifies the checksum once the body is exhausted. Returns the total bytes
-/// downloaded. The caller is responsible for removing `part_path` on error.
-fn stream_and_verify(
-    mod_id: &str,
-    response: &mut reqwest::blocking::Response,
-    part_path: &Path,
-    total_size: Option<u64>,
-    expected_checksum: Option<String>,
-) -> AppResult<u64> {
-    let mut file = File::create(part_path)?;
-    let mut hasher = Sha256::new();
-    let mut downloaded: u64 = 0;
-    let mut chunk = vec![0u8; 64 * 1024];
-    let mut last_pct: i64 = -1;
-
-    emit_progress(mod_id, 0, total_size, "downloading");
-
-    loop {
-        let n = response.read(&mut chunk)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&chunk[..n]);
-        file.write_all(&chunk[..n])?;
-        downloaded += n as u64;
-        // Throttle to whole-percent changes (or a single emit when the size is
-        // unknown/zero) so a large download doesn't flood the event bus.
-        let pct = total_size
-            .and_then(|t| (downloaded * 100).checked_div(t))
-            .unwrap_or(0) as i64;
-        if pct != last_pct {
-            last_pct = pct;
-            emit_progress(mod_id, downloaded, total_size, "downloading");
-        }
-    }
-    drop(file);
-
-    emit_progress(mod_id, downloaded, total_size, "verifying");
-    let computed_checksum = crate::backend::services::hex_digest(hasher.finalize());
-    if let Some(expected_checksum) = expected_checksum.filter(|checksum| !checksum.is_empty())
-        && computed_checksum != expected_checksum.to_lowercase()
-    {
-        return Err(AppError::validation(format!(
-            "Checksum mismatch: expected {}, got {}",
-            expected_checksum, computed_checksum
-        )));
-    }
-
-    Ok(downloaded)
-}
-
 fn get_tracking_id() -> AppResult<String> {
-    use std::fs;
     let dir = crate::backend::directories::app_data_dir()?;
     fs::create_dir_all(&dir)?;
     let path = dir.join("tracking_id");

--- a/src/backend/services/profile_service.rs
+++ b/src/backend/services/profile_service.rs
@@ -417,9 +417,24 @@ pub fn create_profile(name: &str) -> AppResult<ProfileEntry> {
     Ok(profile)
 }
 
+/// The profile with `profile_id`, or a validation error naming it.
+fn load_profile(profile_id: &str) -> AppResult<ProfileEntry> {
+    get_profile_by_id(profile_id)?
+        .ok_or_else(|| AppError::validation(format!("Profile '{profile_id}' not found")))
+}
+
+/// The bare file name of a stored plugin file, rejecting anything that isn't
+/// already a plain name (path separators, `..`, empty).
+fn base_file_name(file: &str) -> AppResult<&str> {
+    Path::new(file)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| *name == file && !file.contains('/') && !file.contains('\\'))
+        .ok_or_else(|| AppError::validation("Invalid mod file name"))
+}
+
 pub fn install_bepinex_for_profile(profile_id: &str) -> AppResult<()> {
-    let mut profile = get_profile_by_id(profile_id)?
-        .ok_or_else(|| AppError::validation(format!("Profile '{profile_id}' not found")))?;
+    let mut profile = load_profile(profile_id)?;
 
     let settings = core_service::get_settings()?;
     let install_arch = settings.game_platform.bepinex_arch();
@@ -449,11 +464,7 @@ pub fn install_bepinex_for_profile(profile_id: &str) -> AppResult<()> {
 }
 
 pub fn delete_profile(profile_id: &str) -> AppResult<()> {
-    let Some(profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let profile = load_profile(profile_id)?;
     let path = PathBuf::from(profile.path);
     if path.exists() {
         fs::remove_dir_all(path)?;
@@ -477,21 +488,13 @@ pub fn rename_profile(profile_id: &str, new_name: &str) -> AppResult<()> {
         )));
     }
 
-    let Some(mut profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let mut profile = load_profile(profile_id)?;
     profile.name = trimmed.to_string();
     write_profile(&profile)
 }
 
 pub fn update_profile_icon(profile_id: &str, selection: ProfileIconSelection) -> AppResult<()> {
-    let Some(mut profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let mut profile = load_profile(profile_id)?;
 
     match selection {
         ProfileIconSelection::Default => {
@@ -561,17 +564,9 @@ pub fn add_mod_to_profile(
     version: &str,
     file: &str,
 ) -> AppResult<()> {
-    let base_name = Path::new(file)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| *name == file && !file.contains('/') && !file.contains('\\'))
-        .ok_or_else(|| AppError::validation("Invalid mod file name"))?;
+    let base_name = base_file_name(file)?;
 
-    let Some(mut profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let mut profile = load_profile(profile_id)?;
 
     if let Some(existing) = profile
         .mods
@@ -604,11 +599,7 @@ pub fn add_mod_to_profile(
 /// Enable or disable a profile's mod. BepInEx only loads `*.dll`, so a disabled
 /// mod is kept on disk as `<file>.disabled` and renamed back when re-enabled.
 pub fn set_mod_enabled(profile_id: &str, mod_id: &str, enabled: bool) -> AppResult<()> {
-    let Some(mut profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let mut profile = load_profile(profile_id)?;
     let Some(index) = profile.mods.iter().position(|m| m.mod_id == mod_id) else {
         return Err(AppError::validation("Mod is not installed in this profile"));
     };
@@ -618,11 +609,7 @@ pub fn set_mod_enabled(profile_id: &str, mod_id: &str, enabled: bool) -> AppResu
         ));
     };
 
-    let base_name = Path::new(&file)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| *name == file && !file.contains('/') && !file.contains('\\'))
-        .ok_or_else(|| AppError::validation("Invalid mod file name"))?;
+    let base_name = base_file_name(&file)?;
 
     let plugins_dir = PathBuf::from(&profile.path).join("BepInEx").join("plugins");
     let enabled_path = plugins_dir.join(base_name);
@@ -641,21 +628,13 @@ pub fn set_mod_enabled(profile_id: &str, mod_id: &str, enabled: bool) -> AppResu
 }
 
 pub fn add_play_time(profile_id: &str, duration_ms: i64) -> AppResult<()> {
-    let Some(mut profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let mut profile = load_profile(profile_id)?;
     profile.total_play_time = Some(profile.total_play_time.unwrap_or(0) + duration_ms);
     write_profile(&profile)
 }
 
 pub fn remove_mod_from_profile(profile_id: &str, mod_id: &str) -> AppResult<()> {
-    let Some(mut profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let mut profile = load_profile(profile_id)?;
     profile.mods.retain(|mod_entry| mod_entry.mod_id != mod_id);
     normalize_icon_selection(&mut profile);
     write_profile(&profile)
@@ -666,11 +645,7 @@ pub fn remove_mod_from_profile(profile_id: &str, mod_id: &str) -> AppResult<()> 
 /// matters for custom mods: [`sync_custom_mods`] would otherwise resurrect the
 /// entry from the leftover DLL on the next profile read.
 pub fn uninstall_mod_from_profile(profile_id: &str, mod_id: &str) -> AppResult<()> {
-    let Some(profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let profile = load_profile(profile_id)?;
     let Some(entry) = profile.mods.iter().find(|m| m.mod_id == mod_id) else {
         return Err(AppError::validation("Mod is not installed in this profile"));
     };
@@ -702,11 +677,7 @@ pub fn import_mod_to_profile(profile_id: &str, source_path: &str) -> AppResult<S
         return Err(AppError::validation("Invalid mod file name"));
     }
 
-    let Some(profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let profile = load_profile(profile_id)?;
 
     let destination = PathBuf::from(&profile.path)
         .join("BepInEx")
@@ -724,13 +695,7 @@ pub fn import_mod_to_profile(profile_id: &str, source_path: &str) -> AppResult<S
 }
 
 pub fn delete_mod_file(profile_path: &str, file_name: &str) -> AppResult<()> {
-    let base_name = Path::new(file_name)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| AppError::validation("Invalid mod file name"))?;
-    if base_name != file_name || file_name.contains('/') || file_name.contains('\\') {
-        return Err(AppError::validation("Invalid mod file name"));
-    }
+    let base_name = base_file_name(file_name)?;
 
     let plugins_dir = PathBuf::from(profile_path).join("BepInEx").join("plugins");
     let path = plugins_dir.join(base_name);
@@ -984,11 +949,7 @@ pub fn import_profile_zip(zip_path: &str) -> AppResult<Vec<ProfileEntry>> {
 }
 
 pub fn export_profile_zip(profile_id: &str, destination: &str) -> AppResult<()> {
-    let Some(profile) = get_profile_by_id(profile_id)? else {
-        return Err(AppError::validation(format!(
-            "Profile '{profile_id}' not found"
-        )));
-    };
+    let profile = load_profile(profile_id)?;
     profile_zip_service::export_profile_zip(profile.path, destination.to_string(), |p| {
         publish_zip_progress(ZipOp::Export, p)
     })

--- a/src/backend/services/update_service.rs
+++ b/src/backend/services/update_service.rs
@@ -56,9 +56,10 @@ fn parse_sha256_digest(digest: &str) -> Option<String> {
 pub fn check_for_update() -> AppResult<Option<UpdateInfo>> {
     info!("checking for updates against {RELEASES_API_URL}");
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(REQUEST_TIMEOUT)
-        .build()?;
+    let client = crate::backend::services::http_download::http_client(
+        REQUEST_TIMEOUT,
+        REQUEST_TIMEOUT,
+    )?;
 
     let release: GithubRelease = client
         .get(RELEASES_API_URL)
@@ -125,7 +126,7 @@ pub fn apply_update_and_relaunch(info: &UpdateInfo) -> AppResult<()> {
         "downloading update {} from {}",
         info.version, info.download_url
     );
-    http_download::download_file(&info.download_url, &download_path, |_, _| {})?;
+    http_download::download_file(&info.download_url, &download_path, None, None, |_, _| {})?;
 
     let Some(expected) = info.expected_sha256.as_deref() else {
         let _ = fs::remove_file(&download_path);


### PR DESCRIPTION
- Simplify AppError to a single message-carrying struct
- Share one HTTP client/download_file helper across api, update, bepinex and mod download services (adds optional header + checksum hashing)
- Dedupe profile lookup and mod file-name validation in profile_service
- Drop unused flate2 dependency