### PR TITLE
add nightly release channel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,12 @@ updates:
           - minor
           - patch
 
-  # Workflow actions (checkout, rust-cache, install-nix, gh-release, …).
+  # Workflow actions (checkout, rust-cache, install-nix, gh-release, …). These
+  # are pinned to full commit SHAs, not tags: the release jobs hold
+  # `contents: write`, so a retargeted tag would be able to publish an
+  # executable under a release users' updaters already trust. Dependabot moves
+  # the SHA and the `# version` comment next to it together, so the pins don't
+  # rot — keep new actions pinned the same way.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,11 @@ jobs:
             path: target/release/Starlight.exe
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install system libraries
         if: runner.os == 'Linux'
@@ -83,7 +83,7 @@ jobs:
         if: runner.os == 'Linux'
         run: bash packaging/linux/build-appimage.sh
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           nix_path: nixpkgs=channel:nixos-25.11
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo check
         run: nix develop --command cargo check --all-targets
@@ -52,13 +52,13 @@ jobs:
   check-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo check
         run: cargo check --all-targets

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,171 @@
+name: Nightly
+
+# Cuts a pre-release from main every night, for users on the nightly channel
+# (Settings → About → Updates in the app). Nothing is published on a night
+# where main didn't move.
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+# Never two nightlies at once — they'd fight over the same tag namespace.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.plan.outputs.changed }}
+      version: ${{ steps.plan.outputs.version }}
+    steps:
+      # Full history so the last nightly tag is available for the diff check.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to build, and as what version
+        id: plan
+        run: |
+          last=$(git tag --list 'v*-nightly.*' --sort=-creatordate | head -n1)
+          if [ -n "$last" ] && [ "$(git rev-list -n1 "$last")" = "$GITHUB_SHA" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No commits since $last — skipping tonight's nightly."
+            exit 0
+          fi
+
+          # A nightly is a pre-release of the *next* patch version, so it sorts
+          # above the release it was cut from and below the release that
+          # supersedes it. That ordering is what the in-app updater walks —
+          # see src/backend/services/update_service.rs.
+          core=$(grep -m1 '^version = "' Cargo.toml | sed -E 's/^version = "([^"-]+).*/\1/')
+          IFS=. read -r major minor patch <<< "$core"
+          version="$major.$minor.$((patch + 1))-nightly.$(date -u +%Y%m%d).$GITHUB_RUN_NUMBER"
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "::notice::Building nightly $version"
+
+  # Nightlies ship the two things testers need — the Windows exe (which is
+  # also what the self-updater installs) plus its installer, and a Linux
+  # binary plus AppImage. The .deb/.rpm/Flatpak packages stay release-only:
+  # they're for distribution channels, and the Flatpak alone would pull a
+  # ~1 GB runtime every night.
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact: nightly-windows-x86_64
+          - os: ubuntu-latest
+            artifact: nightly-linux-x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # The updater compares the running binary's CARGO_PKG_VERSION against the
+      # release tag, so the build has to carry the nightly version. Not
+      # committed — it only exists for this build.
+      - name: Stamp the nightly version into Cargo.toml
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          sed -i "0,/^version = /s|^version = .*|version = \"$VERSION\"|" Cargo.toml
+          grep -m1 '^version = ' Cargo.toml
+
+      - name: Install system libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libfontconfig1-dev \
+            libfreetype-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libwayland-dev \
+            libx11-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxcb1-dev \
+            libgl-dev \
+            libvulkan-dev
+
+      - name: cargo build --release
+        run: cargo build --release
+
+      # The updater matches release assets by exact name — keep the portable
+      # exe named Starlight-windows-x86_64.exe.
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Copy-Item target/release/Starlight.exe Starlight-windows-x86_64.exe
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.prepare.outputs.version }} /O"." packaging\windows\starlight.iss
+
+      - name: Package (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cp target/release/Starlight Starlight-linux-x86_64
+          bash packaging/linux/build-appimage.sh
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            Starlight-windows-x86_64.exe
+            Starlight-Setup-x86_64.exe
+            Starlight-linux-x86_64
+            Starlight-linux-x86_64.AppImage
+          if-no-files-found: error
+
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      # One release for both platforms, tagged at the commit that was built.
+      # Pre-release is what keeps nightlies out of /releases/latest, which is
+      # how the stable channel stays stable.
+      - uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ needs.prepare.outputs.version }}
+          name: Nightly ${{ needs.prepare.outputs.version }}
+          prerelease: true
+          body: |
+            Automated nightly build of `main`. Less tested than a release —
+            expect rough edges.
+
+            To get these automatically, set Settings → About → Updates →
+            Release channel to **Nightly** in Starlight.
+          generate_release_notes: true
+          files: dist/*
+
+      # Nightly builds pile up fast, so keep only the most recent handful —
+      # enough to drop back a few days if one turns out to be broken.
+      - name: Prune old nightlies
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: 5
+        run: |
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \
+            --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease and (.tagName | test("-nightly\\."))) | .tagName' \
+            | tail -n "+$((KEEP + 1))" \
+            | xargs -r -I{} gh release delete {} \
+                --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ steps.plan.outputs.version }}
     steps:
       # Full history so the last nightly tag is available for the diff check.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -65,11 +65,11 @@ jobs:
             artifact: nightly-linux-x86_64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # The updater compares the running binary's CARGO_PKG_VERSION against the
       # release tag, so the build has to carry the nightly version. Not
@@ -118,7 +118,7 @@ jobs:
           cp target/release/Starlight Starlight-linux-x86_64
           bash packaging/linux/build-appimage.sh
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: |
@@ -134,7 +134,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
@@ -142,7 +142,7 @@ jobs:
       # One release for both platforms, tagged at the commit that was built.
       # Pre-release is what keeps nightlies out of /releases/latest, which is
       # how the stable channel stays stable.
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
           name: Nightly ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # The updater compares the running binary's CARGO_PKG_VERSION against
       # the release tag — a mismatch ships an updater that never settles.
@@ -42,7 +42,7 @@ jobs:
           $version = "${{ github.ref_name }}".TrimStart("v")
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" /DMyAppVersion=$version /O"." packaging\windows\starlight.iss
 
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: |
             Starlight-windows-x86_64.exe
@@ -54,11 +54,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # The updater compares the running binary's CARGO_PKG_VERSION against
       # the release tag — a mismatch ships an updater that never settles.
@@ -114,7 +114,7 @@ jobs:
           flatpak-builder --user --force-clean --repo=flatpak-repo flatpak-build packaging/linux/dev.allofus.Starlight.yml
           flatpak build-bundle flatpak-repo Starlight-linux-x86_64.flatpak dev.allofus.Starlight
 
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: |
             Starlight-linux-x86_64

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Get the latest release here:
 
 https://github.com/All-Of-Us-Mods/Starlight-PC/releases/latest
 
+Nightly builds are cut from `main` every night there are changes, and are
+published as pre-releases. To follow them, set Settings → About → Updates →
+Release channel to **Nightly** (Windows only, since that's where the in-app
+updater works) — or just download a pre-release by hand.
+
 ## Screenshots
 
 ### Explore

--- a/locales/app.en.yml
+++ b/locales/app.en.yml
@@ -263,6 +263,8 @@ update:
   title: Update available
   restart: Restart & Update
   failed: "Update failed: %{error}"
+  up_to_date: Starlight is up to date.
+  check_failed: "Update check failed: %{error}"
 settings:
   page:
     game: Game
@@ -278,6 +280,7 @@ settings:
     theme: Theme
     cache: Cache
     download_urls: Download URLs
+    updates: Updates
     runner: Runner
     runner_desc: 'Steam launches via the Steam client (Steam must be running). For modded launches, set the game''s Steam launch options to WINEDLLOVERRIDES="winhttp=n,b" %command%.'
   among_us_path: Among Us path
@@ -339,6 +342,13 @@ settings:
     proton_compat_desc: The game's Steam compatdata folder (steamapps/compatdata/945360). Also used to locate RegionInfo.json for server management.
     steam_run: Wrap Proton in steam-run
     steam_run_desc: Launch Proton via steam-run (NixOS/non-FHS systems). Disable to run the Proton binary directly.
+  release_channel: Release channel
+  release_channel_desc: Stable ships tested releases. Nightly builds every night from the latest code — newer features, rougher edges.
+  channel_stable: Stable
+  channel_nightly: Nightly
+  check_for_updates: Check for updates
+  check_for_updates_desc: Starlight also checks on startup.
+  check_now: Check Now
   license: GNU GPLv3 License
   view_source: View Source
   open_data_folder: Open Data Folder

--- a/src/backend/services/core_service.rs
+++ b/src/backend/services/core_service.rs
@@ -69,6 +69,17 @@ pub enum ScrollbarVisibility {
     Always,
 }
 
+/// Which GitHub releases the self-updater follows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseChannel {
+    /// Tagged releases only.
+    #[default]
+    Stable,
+    /// Also the nightly pre-releases cut from `main`.
+    Nightly,
+}
+
 fn default_true() -> bool {
     true
 }
@@ -143,6 +154,9 @@ pub struct AppSettings {
     /// Width the user dragged the sidebar to; drives icon mode when small.
     #[serde(default = "default_sidebar_width")]
     pub sidebar_width: f32,
+    /// Which releases the self-updater offers (see `update_service`).
+    #[serde(default)]
+    pub release_channel: ReleaseChannel,
 }
 
 impl Default for AppSettings {
@@ -168,6 +182,7 @@ impl Default for AppSettings {
             show_stars_background: true,
             scrollbar_visibility: ScrollbarVisibility::default(),
             sidebar_width: default_sidebar_width(),
+            release_channel: ReleaseChannel::default(),
         }
     }
 }
@@ -194,6 +209,7 @@ pub struct AppSettingsPatch {
     pub show_stars_background: Option<bool>,
     pub scrollbar_visibility: Option<ScrollbarVisibility>,
     pub sidebar_width: Option<f32>,
+    pub release_channel: Option<ReleaseChannel>,
 }
 
 fn settings_path() -> AppResult<PathBuf> {
@@ -388,6 +404,9 @@ pub fn update_settings(patch: AppSettingsPatch) -> AppResult<AppSettings> {
     }
     if let Some(value) = patch.sidebar_width {
         settings.sidebar_width = value;
+    }
+    if let Some(value) = patch.release_channel {
+        settings.release_channel = value;
     }
 
     // Unity refuses to start a second process when this boot.config entry is

--- a/src/backend/services/update_service.rs
+++ b/src/backend/services/update_service.rs
@@ -1,20 +1,31 @@
-//! Self-update check against GitHub Releases, Zed-style: check the latest
-//! release tag against the running version, and if newer, download the
-//! Windows exe and swap it in for the next launch.
+//! Self-update check against GitHub Releases, Zed-style: check the newest
+//! release on the user's channel against the running version, and if newer,
+//! download the Windows exe and swap it in for the next launch.
 //!
 //! Windows-only for now — swapping the running executable relies on the
 //! quirk that Windows allows renaming (but not overwriting) an in-use file.
+//!
+//! Two channels (see [`ReleaseChannel`]): stable follows the tagged releases,
+//! nightly also picks up the pre-releases the nightly workflow cuts from
+//! `main`. Nightly tags are pre-releases of the *next* patch version
+//! (`2.1.1-nightly.20260909.42` when 2.1.0 is out), so a nightly always sorts
+//! above the stable it was cut from and below the stable that supersedes it —
+//! which is what keeps a nightly user moving forward and lets them land back
+//! on stable when that version ships.
 
 use crate::backend::error::{AppError, AppResult};
+use crate::backend::services::core_service::ReleaseChannel;
 use log::info;
 use serde::Deserialize;
 use std::time::Duration;
 
-const RELEASES_API_URL: &str =
-    "https://api.github.com/repos/All-Of-Us-Mods/Starlight-PC/releases/latest";
+const REPO_API_URL: &str = "https://api.github.com/repos/All-Of-Us-Mods/Starlight-PC";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 const RELEASE_DOWNLOAD_PREFIX: &str =
     "https://github.com/All-Of-Us-Mods/Starlight-PC/releases/download/";
+/// The one asset the updater can install. Keep in sync with the release
+/// workflows' artifact names.
+const WINDOWS_ASSET_NAME: &str = "Starlight-windows-x86_64.exe";
 
 #[derive(Debug, Clone)]
 pub struct UpdateInfo {
@@ -33,7 +44,17 @@ struct GithubAsset {
 #[derive(Deserialize)]
 struct GithubRelease {
     tag_name: String,
+    #[serde(default)]
+    draft: bool,
     assets: Vec<GithubAsset>,
+}
+
+impl GithubRelease {
+    fn windows_asset(&self) -> Option<&GithubAsset> {
+        self.assets
+            .iter()
+            .find(|a| a.name.eq_ignore_ascii_case(WINDOWS_ASSET_NAME))
+    }
 }
 
 /// Parse a GitHub asset digest of the form "sha256:<64 hex chars>" into
@@ -50,41 +71,87 @@ fn parse_sha256_digest(digest: &str) -> Option<String> {
     }
 }
 
-/// Check the latest GitHub release against the running version. Returns
-/// `Ok(None)` if we're already up to date or the release has no Windows
-/// asset to offer.
-pub fn check_for_update() -> AppResult<Option<UpdateInfo>> {
-    info!("checking for updates against {RELEASES_API_URL}");
+/// The release to offer: the highest version that actually ships the Windows
+/// asset. Drafts and tags that aren't semver are skipped, and so is a release
+/// whose asset upload didn't land — offering that would hand the user a
+/// notification that can't be installed.
+fn best_release(releases: &[GithubRelease]) -> Option<(semver::Version, &GithubRelease)> {
+    releases
+        .iter()
+        .filter(|r| !r.draft && r.windows_asset().is_some())
+        .filter_map(|r| {
+            let version = semver::Version::parse(r.tag_name.trim_start_matches('v')).ok()?;
+            Some((version, r))
+        })
+        .max_by(|(a, _), (b, _)| a.cmp(b))
+}
 
+/// Whether `candidate` is worth offering to someone running `current`.
+///
+/// Normally that means "newer". The exception is a user who switched from
+/// nightly back to stable: the newest stable is *older* than the nightly they
+/// are running, and without this they'd be stuck on the nightly channel until
+/// the next stable release caught up.
+fn is_upgrade(
+    current: &semver::Version,
+    candidate: &semver::Version,
+    channel: ReleaseChannel,
+) -> bool {
+    candidate > current
+        || (channel == ReleaseChannel::Stable && !current.pre.is_empty() && candidate != current)
+}
+
+fn fetch<T: serde::de::DeserializeOwned>(url: &str) -> AppResult<T> {
     let client =
         crate::backend::services::http_download::http_client(REQUEST_TIMEOUT, REQUEST_TIMEOUT)?;
 
-    let release: GithubRelease = client
-        .get(RELEASES_API_URL)
+    Ok(client
+        .get(url)
         .header("User-Agent", "Starlight-Updater")
         .send()?
         .error_for_status()?
-        .json()?;
+        .json()?)
+}
 
-    let tag = release.tag_name.trim_start_matches('v');
-    let latest = semver::Version::parse(tag)
-        .map_err(|e| AppError::parse(format!("Invalid release tag '{tag}': {e}")))?;
+/// Check the user's channel for a newer build than the running version.
+/// Returns `Ok(None)` if we're already up to date or nothing on the channel
+/// has a Windows asset to offer.
+pub fn check_for_update(channel: ReleaseChannel) -> AppResult<Option<UpdateInfo>> {
     let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))
         .expect("CARGO_PKG_VERSION is valid semver");
 
-    if latest <= current {
-        info!("up to date (running {current}, latest release is {latest})");
+    // `/releases/latest` is GitHub's "newest non-pre-release", which is
+    // exactly the stable channel. Nightlies are pre-releases, so the nightly
+    // channel reads the release list instead and picks the highest version
+    // itself — including stable ones, so a nightly user still lands on a
+    // release when it supersedes their build.
+    let releases: Vec<GithubRelease> = match channel {
+        ReleaseChannel::Stable => {
+            let url = format!("{REPO_API_URL}/releases/latest");
+            info!("checking for updates against {url}");
+            vec![fetch(&url)?]
+        }
+        ReleaseChannel::Nightly => {
+            // 30 covers a month of nightlies, so the newest is always in here.
+            let url = format!("{REPO_API_URL}/releases?per_page=30");
+            info!("checking for updates against {url}");
+            fetch(&url)?
+        }
+    };
+
+    let Some((latest, release)) = best_release(&releases) else {
+        info!("no installable release found on the {channel:?} channel");
+        return Ok(None);
+    };
+
+    if !is_upgrade(&current, &latest, channel) {
+        info!("up to date (running {current}, newest on {channel:?} is {latest})");
         return Ok(None);
     }
 
-    let Some(asset) = release
-        .assets
-        .iter()
-        .find(|a| a.name.eq_ignore_ascii_case("Starlight-windows-x86_64.exe"))
-    else {
-        info!("release {latest} has no Windows asset, skipping");
-        return Ok(None);
-    };
+    let asset = release
+        .windows_asset()
+        .expect("best_release only returns releases with a Windows asset");
 
     if !asset
         .browser_download_url
@@ -96,7 +163,7 @@ pub fn check_for_update() -> AppResult<Option<UpdateInfo>> {
         )));
     }
 
-    info!("update available: {current} -> {latest}");
+    info!("update available on {channel:?}: {current} -> {latest}");
 
     Ok(Some(UpdateInfo {
         version: latest.to_string(),
@@ -189,6 +256,96 @@ fn hash_file_sha256(path: &std::path::Path) -> AppResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Releases as GitHub returns them, so the tests cover the JSON shape
+    /// the updater depends on as well as the picking logic.
+    fn releases(json: &str) -> Vec<GithubRelease> {
+        serde_json::from_str(json).expect("valid release list")
+    }
+
+    fn asset(name: &str) -> String {
+        format!(
+            r#"{{"name": "{name}", "browser_download_url": "{RELEASE_DOWNLOAD_PREFIX}v1.0.0/{name}", "digest": null}}"#
+        )
+    }
+
+    fn release(tag: &str, draft: bool, assets: &[&str]) -> String {
+        let assets: Vec<String> = assets.iter().map(|n| asset(n)).collect();
+        format!(
+            r#"{{"tag_name": "{tag}", "draft": {draft}, "assets": [{}]}}"#,
+            assets.join(",")
+        )
+    }
+
+    fn version(v: &str) -> semver::Version {
+        semver::Version::parse(v).expect("valid version")
+    }
+
+    #[test]
+    fn best_release_picks_the_highest_version() {
+        let list = releases(&format!(
+            "[{},{},{}]",
+            release("v2.1.0", false, &[WINDOWS_ASSET_NAME]),
+            release("v2.2.1-nightly.20260909.42", false, &[WINDOWS_ASSET_NAME]),
+            release("v2.2.1-nightly.20260908.41", false, &[WINDOWS_ASSET_NAME]),
+        ));
+        let (picked, _) = best_release(&list).expect("a release");
+        assert_eq!(picked, version("2.2.1-nightly.20260909.42"));
+    }
+
+    #[test]
+    fn best_release_skips_drafts_and_releases_without_the_windows_asset() {
+        let list = releases(&format!(
+            "[{},{},{}]",
+            release("v3.0.0", true, &[WINDOWS_ASSET_NAME]),
+            release("v2.9.0", false, &["Starlight-linux-x86_64"]),
+            release("v2.1.0", false, &[WINDOWS_ASSET_NAME]),
+        ));
+        let (picked, _) = best_release(&list).expect("a release");
+        assert_eq!(picked, version("2.1.0"));
+    }
+
+    #[test]
+    fn best_release_skips_tags_that_are_not_semver() {
+        let list = releases(&format!(
+            "[{},{}]",
+            release("nightly", false, &[WINDOWS_ASSET_NAME]),
+            release("v2.1.0", false, &[WINDOWS_ASSET_NAME]),
+        ));
+        let (picked, _) = best_release(&list).expect("a release");
+        assert_eq!(picked, version("2.1.0"));
+    }
+
+    #[test]
+    fn best_release_returns_none_when_nothing_is_installable() {
+        let list = releases(&format!("[{}]", release("v2.1.0", true, &[])));
+        assert!(best_release(&list).is_none());
+    }
+
+    #[test]
+    fn nightly_sorts_between_the_stable_it_follows_and_the_next_one() {
+        assert!(version("2.1.0") < version("2.1.1-nightly.20260909.42"));
+        assert!(version("2.1.1-nightly.20260909.42") < version("2.1.1"));
+    }
+
+    #[test]
+    fn is_upgrade_accepts_newer_and_rejects_same_or_older() {
+        for channel in [ReleaseChannel::Stable, ReleaseChannel::Nightly] {
+            assert!(is_upgrade(&version("2.1.0"), &version("2.1.1"), channel));
+            assert!(!is_upgrade(&version("2.1.0"), &version("2.1.0"), channel));
+            assert!(!is_upgrade(&version("2.1.1"), &version("2.1.0"), channel));
+        }
+    }
+
+    #[test]
+    fn is_upgrade_moves_a_nightly_back_onto_the_stable_channel() {
+        let nightly = version("2.1.1-nightly.20260909.42");
+        let stable = version("2.1.0");
+        assert!(is_upgrade(&nightly, &stable, ReleaseChannel::Stable));
+        // On the nightly channel the same pair is a downgrade, so it isn't
+        // offered — the next nightly will be.
+        assert!(!is_upgrade(&nightly, &stable, ReleaseChannel::Nightly));
+    }
 
     #[test]
     fn parse_sha256_digest_accepts_valid_digest() {

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -14,6 +14,8 @@ use log::warn;
 use crate::backend::events::{self, BackendEvent};
 #[cfg(unix)]
 use crate::backend::services::core_service::LinuxRunnerKind;
+#[cfg(windows)]
+use crate::backend::services::core_service::ReleaseChannel;
 use crate::backend::services::{
     bepinex_service::{self, BepInExTargetType},
     core_service::{self, AppSettingsPatch, GamePlatform, ScrollbarVisibility},
@@ -255,6 +257,21 @@ fn patch_scrollbar_visibility(value: SharedString, cx: &mut App) {
     );
     crate::theme::apply_scrollbar_visibility(cx);
     cx.refresh_windows();
+}
+
+#[cfg(windows)]
+fn patch_release_channel(value: SharedString, cx: &mut App) {
+    let channel = match value.as_ref() {
+        "nightly" => ReleaseChannel::Nightly,
+        _ => ReleaseChannel::Stable,
+    };
+    app_settings::update(
+        cx,
+        AppSettingsPatch {
+            release_channel: Some(channel),
+            ..Default::default()
+        },
+    );
 }
 
 fn patch_bepinex_url_x64(value: SharedString, cx: &mut App) {
@@ -935,6 +952,47 @@ impl Render for SettingsView {
             )
         };
 
+        // Only Windows can install an update in place (see `update_service`),
+        // so only Windows gets a say in which builds it looks for.
+        #[cfg(windows)]
+        let updates_group = SettingGroup::new()
+            .title(t!("settings.group.updates"))
+            .items(vec![
+                SettingItem::new(
+                    t!("settings.release_channel"),
+                    SettingField::dropdown(
+                        vec![
+                            (
+                                "stable".into(),
+                                t!("settings.channel_stable").to_string().into(),
+                            ),
+                            (
+                                "nightly".into(),
+                                t!("settings.channel_nightly").to_string().into(),
+                            ),
+                        ],
+                        |cx| match app_settings::get(cx).release_channel {
+                            ReleaseChannel::Stable => "stable".into(),
+                            ReleaseChannel::Nightly => "nightly".into(),
+                        },
+                        patch_release_channel,
+                    ),
+                )
+                .description(t!("settings.release_channel_desc").to_string()),
+                SettingItem::new(
+                    t!("settings.check_for_updates"),
+                    SettingField::render(|_, _, _| {
+                        Button::new("check-for-updates")
+                            .icon(Icon::new(AppIcon::Download))
+                            .label(t!("settings.check_now"))
+                            .on_click(|_, window, cx| {
+                                crate::workspace::check_for_update(window, cx, true)
+                            })
+                    }),
+                )
+                .description(t!("settings.check_for_updates_desc").to_string()),
+            ]);
+
         let about_page =
             SettingPage::new(t!("settings.page.about")).group(SettingGroup::new().items(vec![
                 SettingItem::render(|_, _window, cx| {
@@ -1008,6 +1066,9 @@ impl Render for SettingsView {
                         )
                 }),
             ]));
+
+        #[cfg(windows)]
+        let about_page = about_page.group(updates_group);
 
         crate::views::page_root("settings-page", &theme)
             .overflow_y_scrollbar()

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -222,7 +222,7 @@ impl Workspace {
         Self::reload_last_launched(cx);
 
         #[cfg(windows)]
-        Self::check_for_update(window, cx);
+        Self::check_for_update_on_startup(window, cx);
 
         Self::first_run_detect_game(window, cx);
         Self::offer_legacy_migration(library.clone(), window, cx);
@@ -401,31 +401,16 @@ impl Workspace {
         .detach();
     }
 
-    /// Check GitHub Releases for a newer build a few seconds after startup
-    /// (so it doesn't compete with the initial UI render) and, if found,
-    /// surface a notification offering to install it.
+    /// Run the update check a few seconds after startup, so it doesn't
+    /// compete with the initial UI render.
     #[cfg(windows)]
-    fn check_for_update(window: &mut Window, cx: &mut Context<Self>) {
-        use crate::backend::services::update_service;
-
+    fn check_for_update_on_startup(window: &mut Window, cx: &mut Context<Self>) {
         let window_handle = window.window_handle();
         cx.spawn(async move |_, cx| {
             cx.background_executor()
                 .timer(std::time::Duration::from_secs(3))
                 .await;
-            let update = cx
-                .background_executor()
-                .spawn(async { update_service::check_for_update() })
-                .await;
-            match update {
-                Ok(Some(info)) => {
-                    let _ = window_handle.update(cx, |_, window, cx| {
-                        window.push_notification(update_notification(info), cx);
-                    });
-                }
-                Ok(None) => {}
-                Err(e) => warn!("update check failed: {e}"),
-            }
+            let _ = window_handle.update(cx, |_, window, cx| check_for_update(window, cx, false));
         })
         .detach();
     }
@@ -956,6 +941,42 @@ impl Render for Workspace {
                 el.child(self.render_sidebar_resize_capture(cx))
             })
     }
+}
+
+/// Check the user's release channel for a build newer than this one and, if
+/// there is one, offer to install it.
+///
+/// `report_no_update` is what separates the two callers: the check on startup
+/// stays quiet unless there's something to install, while the button in
+/// Settings has to answer either way.
+#[cfg(windows)]
+pub(crate) fn check_for_update(window: &mut Window, cx: &mut App, report_no_update: bool) {
+    use crate::backend::services::update_service;
+
+    let channel = app_settings::get(cx).release_channel;
+    let window_handle = window.window_handle();
+    cx.spawn(async move |cx| {
+        let update = cx
+            .background_executor()
+            .spawn(async move { update_service::check_for_update(channel) })
+            .await;
+        let notification = match update {
+            Ok(Some(info)) => update_notification(info),
+            Ok(None) if report_no_update => Notification::info(t!("update.up_to_date").to_string()),
+            Ok(None) => return,
+            Err(e) => {
+                warn!("update check failed: {e}");
+                if !report_no_update {
+                    return;
+                }
+                Notification::error(t!("update.check_failed", error = e).to_string())
+            }
+        };
+        let _ = window_handle.update(cx, |_, window, cx| {
+            window.push_notification(notification, cx);
+        });
+    })
+    .detach();
 }
 
 /// Build the "update available" notification, with an action button that


### PR DESCRIPTION
## Summary

- Add nightly GitHub release workflow for Windows and Linux builds.
- Add stable/nightly release channel selection in Windows settings.
- Update self-updater to select installable releases by channel.
- Document nightly builds and add update status notifications.

## Testing

- Added unit tests for release selection, version ordering, and channel switching.
- Not run locally.